### PR TITLE
Fix version catalog not being used in convention plugins

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -19,6 +19,10 @@ dependencies {
     implementation(libs.quilt.loom)
 
     implementation(libs.gson)
+
+    // Enable using version catalog in local plugins
+    // https://github.com/gradle/gradle/issues/15383
+    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }
 
 kotlin {

--- a/build-logic/src/main/kotlin/kit_tunes.module.gradle.kts
+++ b/build-logic/src/main/kotlin/kit_tunes.module.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.accessors.dm.LibrariesForLibs
 import net.pixaurora.kit_tunes.build_logic.ProjectMetadata
 
 plugins {
@@ -6,6 +7,7 @@ plugins {
     id("org.quiltmc.loom")
 }
 
+val libs = the<LibrariesForLibs>()
 val metadata = extra.get("metadata") as ProjectMetadata
 
 loom {
@@ -15,7 +17,7 @@ loom {
 }
 
 dependencies {
-    modImplementation("org.quiltmc:quilt-loader:0.26.0")
+    modImplementation(libs.quilt.loader)
 
     mappings(loom.officialMojangMappings())
     minecraft("com.mojang:minecraft:${project.property("minecraft_version")}")

--- a/build-logic/src/main/kotlin/kit_tunes.submodule.gradle.kts
+++ b/build-logic/src/main/kotlin/kit_tunes.submodule.gradle.kts
@@ -4,8 +4,8 @@ plugins {
     id("kit_tunes.module")
 }
 
-val minecraft_version_min = project.property("minecraft_version_min") as String
-val minecraft_version_max = project.property("minecraft_version_max") as String
+val minecraftVersionMin = project.property("minecraft_version_min") as String
+val minecraftVersionMax = project.property("minecraft_version_max") as String
 
 configure<ModResourcesExtension>{
     metadata {
@@ -14,6 +14,6 @@ configure<ModResourcesExtension>{
     }
 
     dependencies {
-        required("minecraft").version(minecraft_version_min, minecraft_version_max)
+        required("minecraft").version(minecraftVersionMin, minecraftVersionMax)
     }
 }


### PR DESCRIPTION
I didn't know how to do this yet when switching the convention plugins to Kotlin.