### PR TITLE
Update cargo release config to produce smaller library files

### DIFF
--- a/projects/kitten-thoughts/Cargo.toml
+++ b/projects/kitten-thoughts/Cargo.toml
@@ -13,3 +13,8 @@ tokio = "1.40.0"
 [lib]
 crate-type = ["cdylib"]
 path = "src/main/rust/lib.rs"
+
+[profile.release]
+lto = true
+strip = true
+codegen-units = 1


### PR DESCRIPTION
The `aarch64-pc-windows-msvc` dll size goes from `3367 KiB` to only `2738 KiB`.