### PR TITLE
Add automatic release publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,12 @@
+import me.modmuss50.mpp.ReleaseType
+import net.fabricmc.loom.task.RemapJarTask
+import org.gradle.kotlin.dsl.support.uppercaseFirstChar
+
 plugins {
     id("kit_tunes.java.17")
     id("kit_tunes.module")
     id("kit_tunes.default_resources")
+    alias(libs.plugins.mod.publish.plugin)
 }
 
 mod {
@@ -30,4 +35,48 @@ dependencies {
 
 tasks.withType<Jar> {
     from("LICENSE")
+}
+
+val modVersion = project.property("mod_version").toString()
+val updateTitle = project.property("update_title").toString().uppercaseFirstChar()
+
+fun getVersionType(): ReleaseType {
+    return if (modVersion.startsWith("0.") || modVersion.contains("-alpha.")) {
+        ReleaseType.ALPHA;
+    } else if (modVersion.contains("-")) {
+        ReleaseType.BETA;
+    } else {
+        ReleaseType.STABLE;
+    }
+}
+
+publishMods {
+    version = modVersion
+    displayName = "Kit Tunes $updateTitle $modVersion"
+
+    type = getVersionType()
+    modLoaders.add("quilt")
+
+    file = tasks.withType<RemapJarTask>()["remapJar"].archiveFile
+    changelog = file(rootDir.toPath().resolve("src/main/resources/changelog/${modVersion}.txt")).readText()
+
+    github {
+        accessToken = providers.environmentVariable("GITHUB_SECRET")
+
+        commitish = "meow"
+        tagName = "v${modVersion}"
+        repository = "Pixaurora/Kit-Tunes"
+    }
+
+    modrinth {
+        accessToken = providers.environmentVariable("MODRINTH_SECRET")
+        projectId = "AVOKl7hB"
+
+        minecraftVersionRange {
+            start = project.property("publish_version_min").toString()
+            end = project.property("publish_version_max").toString()
+        }
+
+        optional("fabric-api", "qsl", "modmenu")
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,17 @@ org.gradle.caching = true
 org.gradle.parallel = true
 org.gradle.configureondemand = true
 
+# Java Properties
+maven_group = net.pixaurora
+
 # Mod Properties
 mod_version = 0.4.0
 update_title = axolotl
 description = Helps you appreciate this game's music a bit more!
 
-maven_group = net.pixaurora
 mod_id = kit_tunes
-
 minecraft_version = 1.20.4
+
+# Mod Publish Properties
+publish_version_min = 1.17
+publish_version_max = 1.21.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,8 @@ annotations = "13.0"
 gson = "2.8.0"
 slf4j = "2.0.13"
 
+mod_publish = "0.7.4"
+
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 
@@ -26,3 +28,4 @@ slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 [bundles]
 
 [plugins]
+mod_publish_plugin = { id = "me.modmuss50.mod-publish-plugin", version.ref = "mod_publish" }

--- a/src/main/resources/changelog/0.1.0.txt
+++ b/src/main/resources/changelog/0.1.0.txt
@@ -1,0 +1,1 @@
+A is for Axolotl, but also Alpha!

--- a/src/main/resources/changelog/0.2.0.txt
+++ b/src/main/resources/changelog/0.2.0.txt
@@ -1,0 +1,21 @@
+With this release, there's a new art-style which I think might stick! As well, thank @LostLuma for adding support for many more Minecraft versions
+
+# General changes
+
+- Change music events to use a single object as argument, so that future changes won't break mods that use it (by @Pixaurora)
+- Improve music metadata loading (by @Pixaurora)
+- Add icons for all included projects (by @Pixaurora)
+- Rename projects and add new descriptions (by @Pixaurora)
+- Fix album art input & add official album art to the toasts (by @Pixaurora)
+- Create a new texture for toast backgrounds, & center the title's text (by @Pixaurora)
+- Redo main mod icon (by @Pixaurora)
+
+# Version support changes
+
+- Now supports Minecraft 1.17.0 - 1.21.1 (by @LostLuma)
+
+# Build time changes
+
+- Generate mod metadata & copy icons to the corresponding projects at build time (by @Pixaurora)
+- Improve project organization (by @Pixaurora)
+- Fix version catalog not working in convention plugins (by @LostLuma)

--- a/src/main/resources/changelog/0.3.0.txt
+++ b/src/main/resources/changelog/0.3.0.txt
@@ -1,0 +1,12 @@
+This update fixes a bug, allows music metadata to be translated, and adds atomic saving so data corruption doesn't happen if saving fails mid-save!
+
+# Changes:
+
+- Fix C418's Nether music not being recognized after 1.20.3 (by Pixaurora)
+- Fix the mod asking for QSL in 1.17, since it didn't exist yet (by Pixaurora)
+- Update the music metadata format, allowing tracks to be in separate files from where albums are stored (by Pixaurora)
+- Add the ability for albums, artists, and tracks to be translated (by Pixaurora)
+- Add English translations for all music metadata in the base game, to make it easier for translators to translate them (by Pixaurora)
+- Shorten the translated names of the post 1.16 albums to not have (Original Game Soundtrack) in the name (by Pixaurora)
+- Add atomic saving (by Pixaurora, LostLuma)
+- Change the 'Owner' role to 'Author' in mod metadata (by Pixaurora)

--- a/src/main/resources/changelog/0.4.0.txt
+++ b/src/main/resources/changelog/0.4.0.txt
@@ -1,0 +1,17 @@
+This mod adds Rust to the mix (the programming language, not the game!) as well as a brand-new logo, updated colors, and home screen! There will also be more graphical changes in the next few updates, so stay tuned and follow the mod on Modrinth!
+
+# General Changes
+
+- Add the ability to safely download and use native libraries (by @LostLuma)
+- Switch from using Java's dilapidated HTTP server to instead use a Rocket server made in Rust (by @Pixaurora)
+- Update the description on Last.FM and also the callback used to register the Scrobbler (by @Pixaurora)
+- Add a logo, background, and custom button texture to be used in screens (by @Pixaurora)
+- Fix the Wild Update album's name to be in line with MusicBrainz (by @Pixaurora)
+- Remove confirm screen when opening the scrobbler registration link, and open it automatically (by @Pixaurora)
+- Add the 'Catculator' library project, with a really cute icon (by @Pixaurora)
+- Update all the assets to use more colors (by @Pixaurora)
+
+# Build Time Changes
+
+- Use settings to make the native code size is as small as possible (by @LostLuma)
+- Build the Rust library for Windows, macOS, and Linux on aarch64 and amd64 architectures in GitHub (by @LostLuma)


### PR DESCRIPTION
Adds a new `publishmods` Gradle task using the [Mod Publish Plugin](https://github.com/modmuss50/mod-publish-plugin).
This will automatically create the GitHub Tag, GitHub Release, and Modrinth Release when run.

To do so you must follow these steps:
- Create a file named `<version>.txt` at `src/main/resources/changelog` with the changelog
- Set the `GITHUB_SECRET` and `MODRINTH_SECRET` environment variables with your PATs from the platforms
- Run `./gradlew publishmods` and enjoy a hassle-free life because you no longer have to suffer with the Modrinth frontend

I've already created the changelog files for all versions including `0.4.0` for you (and fixed some typos).
You will want to delete the `v0.4.0` tag and release on GitHub since the plugin will try to create them for you again.