### PR TITLE
Fix scrobbler setup screen keeping the browser prompt

### DIFF
--- a/projects/kitten-heart/src/main/java/net/pixaurora/kitten_cube/impl/ui/widget/text/PushableTextLines.java
+++ b/projects/kitten-heart/src/main/java/net/pixaurora/kitten_cube/impl/ui/widget/text/PushableTextLines.java
@@ -28,6 +28,10 @@ public class PushableTextLines implements Widget {
         return startPos.offset(0, this.height());
     }
 
+    public void clear() {
+        this.lines.clear();
+    }
+
     public void push(Component text, Color color) {
         Point newLinePos = MinecraftClient.textSize(text).centerHorizontally(startPos).offset(0, this.height());
         this.lines.add(new PositionedText(text, color, newLinePos));

--- a/projects/kitten-heart/src/main/java/net/pixaurora/kitten_heart/impl/ui/screen/scrobbler/ScrobblerSetupScreen.java
+++ b/projects/kitten-heart/src/main/java/net/pixaurora/kitten_heart/impl/ui/screen/scrobbler/ScrobblerSetupScreen.java
@@ -48,12 +48,15 @@ public class ScrobblerSetupScreen<T extends Scrobbler> extends KitTunesScreenTem
         this.setupStatus = Optional.empty();
     }
 
-    private void sendMessage(Component message) {
-        this.setupStatus.get().push(message, Color.WHITE);
+    private void setMessage(Component message) {
+        PushableTextLines output = this.setupStatus.orElseThrow(RuntimeException::new);
+
+        output.clear();
+        output.push(message, Color.WHITE);
     }
 
     private void sendError(KitTunesException exception) {
-        PushableTextLines output = this.setupStatus.get();
+        PushableTextLines output = this.setupStatus.orElseThrow(RuntimeException::new);
 
         output.push(exception.userMessage(), Color.RED);
         if (exception.isPrinted()) {
@@ -84,7 +87,7 @@ public class ScrobblerSetupScreen<T extends Scrobbler> extends KitTunesScreenTem
         try {
             this.awaitedScrobbler = Optional.of(this.scrobblerType.setup(5, TimeUnit.MINUTES));
 
-            this.sendMessage(SETUP_STARTED);
+            this.setMessage(SETUP_STARTED);
         } catch (IOException e) {
             this.sendError(new ScrobblerSetupStartException(e));
 
@@ -121,7 +124,7 @@ public class ScrobblerSetupScreen<T extends Scrobbler> extends KitTunesScreenTem
                     T scrobbler = awaitedScrobbler.get();
                     this.saveScrobbler(scrobbler);
 
-                    this.sendMessage(SETUP_COMPLETED);
+                    this.setMessage(SETUP_COMPLETED);
                 } catch (ExecutionException | InterruptedException | IOException e) {
                     this.sendError(KitTunesException.convert(e));
                 }


### PR DESCRIPTION
Removes the "Check your browser! ..." message after the user has done the steps in the browser.