### PR TITLE
Run workflows only if matching files were changed

### DIFF
--- a/.github/workflows/build-java.yaml
+++ b/.github/workflows/build-java.yaml
@@ -1,6 +1,15 @@
-name: build
+name: build-java
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - meow
+    paths-ignore:
+      - projects/catculator/**
+  pull_request:
+    paths-ignore:
+      - projects/catculator/**
 
 jobs:
   build:

--- a/.github/workflows/build-natives.yaml
+++ b/.github/workflows/build-natives.yaml
@@ -1,6 +1,15 @@
 name: build-natives
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - meow
+    paths:
+      - projects/catculator/**
+  pull_request:
+    paths:
+      - projects/catculator/**
 
 jobs:
   build:


### PR DESCRIPTION
Stops the full CI suite running on every commit, even if the matching subproject was not changed.
You can still manually trigger both workflows using the `workflow_dispatch` (there's a button in the GitHub UI).