### PR TITLE
Allow publishing for multiple Minecraft version ranges

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,4 @@ mod_id = kit_tunes
 minecraft_version = 1.20.4
 
 # Mod Publish Properties
-publish_version_min = 1.17
-publish_version_max = 1.21.4
+publish_versions = b1.7.3-b1.7.3,1.16-1.21.4

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ annotations = "13.0"
 gson = "2.8.0"
 slf4j = "2.0.13"
 
-mod_publish = "0.7.4"
+mod_publish = "0.8.4"
 
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }


### PR DESCRIPTION
Allows publishing for multiple Minecraft version ranges at once, instead of a single one.

To do so there's a new `publish_versions` property, a comma separated list of version ranges, e.g. `b1.7-b1.7.3,1.0-1.2.5`.
If one or more versions inside a version range is a snapshot the version range is marked as including all snapshots in the range.